### PR TITLE
ios token paste prompt now fully displayed

### DIFF
--- a/iosApp/iosApp/Views/Components/MoreTextFieldHL.swift
+++ b/iosApp/iosApp/Views/Components/MoreTextFieldHL.swift
@@ -29,7 +29,7 @@ struct MoreTextFieldHL: View {
             
             HStack{
                 Spacer()
-                SectionHeading(sectionTitle: headerText)
+                SectionHeading(sectionTitle: headerText, showAllText: true)
                 Spacer()
             }
             .padding(3)

--- a/iosApp/iosApp/Views/Components/SectionHeading.swift
+++ b/iosApp/iosApp/Views/Components/SectionHeading.swift
@@ -18,9 +18,16 @@ import SwiftUI
 struct SectionHeading: View {
     var sectionTitle: String
     var font: Font = Font.more.headline
+    var showAllText = false
     
     var body: some View {
-        Text(sectionTitle)
-            .font(font)
+        if showAllText {
+            Text(sectionTitle)
+                .font(font)
+                .fixedSize(horizontal: false, vertical: true)
+        } else {
+            Text(sectionTitle)
+                .font(font)
+        }
     }
 }


### PR DESCRIPTION
fixed issue on ios where the prompt to enter the token is not fully displayed