### PR TITLE
fixed bug on android that when no permissions are required, or if the…

### DIFF
--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
@@ -153,6 +153,7 @@ fun checkPermissions(
         launcher.launch(permissions.toTypedArray())
         false
     } else {
+        launcher.launch(permissions.toTypedArray())
         true
     }
 }

--- a/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
+++ b/androidApp/src/main/java/io/redlink/more/app/android/activities/consent/composables/ConsentButtons.kt
@@ -133,7 +133,9 @@ fun checkAndRequestPermissions(
     if (hasBackgroundLocationPermission) {
         permissions.remove(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
     }
-    if (hasBackgroundLocationPermission) {
+    if(permissions.isEmpty()) {
+        model.acceptConsent(context)
+    } else if (hasBackgroundLocationPermission) {
         checkPermissionForBackgroundLocationAccess(context, launcher, model)
     } else {
         checkPermissions(context, launcher, permissions)
@@ -153,7 +155,6 @@ fun checkPermissions(
         launcher.launch(permissions.toTypedArray())
         false
     } else {
-        launcher.launch(permissions.toTypedArray())
         true
     }
 }


### PR DESCRIPTION
…y are accepted, the study is left and you try to log in with a new token, then the permission accept button is unresponsive